### PR TITLE
fix(taglib): Fix Illumos build - #2067

### DIFF
--- a/scanner/metadata/taglib/taglib_wrapper.go
+++ b/scanner/metadata/taglib/taglib_wrapper.go
@@ -2,7 +2,7 @@ package taglib
 
 /*
 #cgo pkg-config: taglib
-#cgo LDFLAGS: -lstdc++
+#cgo LDFLAGS: -lstdc++ -lsendfile
 #cgo linux darwin CXXFLAGS: -std=c++11
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Build currently fails on Illumos with error `Undefined symbol sendfile`. Fix it by linking `sendfile` explicitly.

Output before patch:

```
$ GOOS=illumos CGO_ENABLED=1 gmake build
WARNING: This command does not build the frontend, it uses the latest built with 'make buildjs'
go build -ldflags="-X github.com/navidrome/navidrome/consts.gitSha=62609270 -X github.com/navidrome/navidrome/consts.gitTag=v0.48.0-SNAPSHOT" -tags=netgo
# github.com/navidrome/navidrome
/opt/local/go118/pkg/tool/solaris_amd64/link: running g++ failed: exit status 1
Undefined                       first referenced
 symbol                             in file
sendfile                            /tmp/go-link-1916572260/go.o
ld: fatal: symbol referencing errors. No output written to $WORK/b001/exe/a.out
collect2: error: ld returned 1 exit status

gmake: *** [Makefile:73: build] Error 2
$
```

Output after patch:
```
$ GOOS=illumos CGO_ENABLED=1 gmake build
WARNING: This command does not build the frontend, it uses the latest built with 'make buildjs'
go build -ldflags="-X github.com/navidrome/navidrome/consts.gitSha=62609270 -X github.com/navidrome/navidrome/consts.gitTag=v0.48.0-SNAPSHOT" -tags=netgo
$ echo $?
0
$
```